### PR TITLE
docs: simplify backend link label

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 Frontend for the 3AM car showcase and accessories store. Built as a small SPA with a lightweight `View` system,
 sections, and pages.
 
-Backend repo: [ali7510/3AM-Project](https://github.com/ali7510/3AM-Project)
+[Backend repository](https://github.com/ali7510/3AM-Project)

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -1,6 +1,6 @@
 # 3AM Frontend Guide
 
-> Note: This repo is frontend only. Backend: [ali7510/3AM-Project](https://github.com/ali7510/3AM-Project)
+> Note: This repo is frontend only. [Backend repository](https://github.com/ali7510/3AM-Project)
 
 The UI is built with `View` classes. Components, sections, and pages are all `View` subclasses that render into the DOM
 and clean up after themselves.


### PR DESCRIPTION
Changed backend link label from "Backend: [Ali/etc]" to "[Backend]".
